### PR TITLE
[engine] Fix NPE while collecting variables data containing variable with `null` value

### DIFF
--- a/vividus-engine/src/main/java/org/vividus/variable/Variables.java
+++ b/vividus-engine/src/main/java/org/vividus/variable/Variables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,10 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -72,9 +70,12 @@ public class Variables
 
     public Map<String, Object> getVariables()
     {
+        // Do not use Collectors#toMap, it results in NPE, it's OpenJDK bug:
+        // https://stackoverflow.com/questions/24630963/nullpointerexception-in-collectors-tomap-with-null-entry-values
+        // https://bugs.openjdk.java.net/browse/JDK-8148463
         return concatedVariables().map(Map::entrySet)
-                                  .flatMap(Set::stream)
-                                  .collect(Collectors.toMap(Entry::getKey, Entry::getValue, (k1, k2) -> k2));
+                .flatMap(Set::stream)
+                .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
     }
 
     private Optional<Object> getVariable(Map<String, Object> variables, VariableKey variableKey)

--- a/vividus-engine/src/test/java/org/vividus/variable/VariablesTests.java
+++ b/vividus-engine/src/test/java/org/vividus/variable/VariablesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -185,7 +186,14 @@ class VariablesTests
         variables.putStoryVariable(KEY2, STORY);
         variables.putStoryVariable(KEY3, STORY);
         variables.putStoryVariable(KEY3, STEP);
-        assertEquals(Map.of(KEY1, SCENARIO, KEY2, STORY, KEY3, STEP), variables.getVariables());
+        var keyWithNullValue = "key-with-null-value";
+        variables.putStoryVariable(keyWithNullValue, null);
+        Map<String, String> expected = new HashMap<>();
+        expected.put(KEY1, SCENARIO);
+        expected.put(KEY2, STORY);
+        expected.put(KEY3, STEP);
+        expected.put(keyWithNullValue, null);
+        assertEquals(expected, variables.getVariables());
     }
 
     private record Pojo(String name)


### PR DESCRIPTION
pr_rerun fix-npe-at-retrieval-dataset-containing-variable-with-null-value to master