### PR TITLE
[plugin-kafka] Increase event consumer timeout to make sure tests pass on slow machines

### DIFF
--- a/vividus-plugin-kafka/src/test/java/org/vividus/steps/kafka/KafkaStepsIntegrationTests.java
+++ b/vividus-plugin-kafka/src/test/java/org/vividus/steps/kafka/KafkaStepsIntegrationTests.java
@@ -175,7 +175,7 @@ class KafkaStepsIntegrationTests
         kafkaSteps.setEventHeaders(headers);
         kafkaSteps.sendEvent(anyDataWithHeader, PRODUCER, TOPIC);
 
-        kafkaSteps.waitForKafkaEvents(Duration.ofSeconds(10), CONSUMER, ComparisonRule.EQUAL_TO, 6);
+        kafkaSteps.waitForKafkaEvents(Duration.ofSeconds(20), CONSUMER, ComparisonRule.EQUAL_TO, 6);
         kafkaSteps.stopKafkaListener(CONSUMER);
         kafkaSteps.processKafkaEvents(QueueOperation.PEEK, CONSUMER, SCOPES, VARIABLE_NAME);
 


### PR DESCRIPTION
pr_rerun fix-kafka-integration-tests to master